### PR TITLE
FIX for boolean datatypes

### DIFF
--- a/etil-compiler/src/main/java/com/tractive/android/etil/compiler/EtilTableAnnotatedClass.java
+++ b/etil-compiler/src/main/java/com/tractive/android/etil/compiler/EtilTableAnnotatedClass.java
@@ -22,10 +22,9 @@ public class EtilTableAnnotatedClass {
 
         info.fieldName = _member.getSimpleName().toString();
         info.columnName = _member.getAnnotation(EtilField.class).value();
+        info.fieldType = _member.asType().toString().toLowerCase();
 
-        String fieldType = _member.asType().toString().toLowerCase();
-
-        switch (fieldType) {
+        switch ( info.fieldType) {
             case "int":
                 info.accessMethod = "getInt";
 
@@ -39,8 +38,9 @@ public class EtilTableAnnotatedClass {
 
                 break;
             case "boolean":
+                //getBoolean does not exist in sqlite -> http://stackoverflow.com/questions/4088080/get-boolean-from-database-using-android-and-sqlite.
+                // That is why we handle the field in the EditTableClasses separately for booleans.
                 info.accessMethod = "getInt";
-
                 break;
             case "float":
                 info.accessMethod = "getFloat";
@@ -51,7 +51,7 @@ public class EtilTableAnnotatedClass {
 
                 break;
             default:
-                throw new IllegalArgumentException("EtilField Type is not supported: " + fieldType);
+                throw new IllegalArgumentException("EtilField Type is not supported: " + info.fieldType);
 
         }
 
@@ -64,6 +64,7 @@ public class EtilTableAnnotatedClass {
         public String fieldName;
         public String columnName;
         public String accessMethod;
+        public String fieldType;
     }
 
     private String mTableName;

--- a/etil-compiler/src/main/java/com/tractive/android/etil/compiler/EtilTableClasses.java
+++ b/etil-compiler/src/main/java/com/tractive/android/etil/compiler/EtilTableClasses.java
@@ -50,7 +50,7 @@ public class EtilTableClasses {
 
                 .returns(TypeVariableName.get("T"))
                 .addTypeVariable(TypeVariableName.get("T"))
-                .addParameter(ParameterizedTypeName.get(ClassName.get("java.lang","Class"), TypeVariableName.get("T")), "_class")
+                .addParameter(ParameterizedTypeName.get(ClassName.get("java.lang", "Class"), TypeVariableName.get("T")), "_class")
                 .addParameter(mCursorClass, "_cursor")
                 .beginControlFlow("switch (_class.getSimpleName())");
 
@@ -87,8 +87,10 @@ public class EtilTableClasses {
                     .addStatement("$L model = new $L()", _modelClass.getTypeElement(), _modelClass.getTypeElement());
 
             for (com.tractive.android.etil.compiler.EtilTableAnnotatedClass.FieldAndColumnInfo _info : _modelClass.getFieldAndColumnInfo()) {
-                builder.addStatement(
-                        "model." + _info.fieldName + " = " + "_cursor." + _info.accessMethod + "(_cursor.getColumnIndex(\"" + _info.columnName + "\"))");
+                if (_info.fieldType.equals("boolean"))
+                    builder.addStatement("model." + _info.fieldName + " = " + "_cursor.getInt(_cursor.getColumnIndex(\"" + _info.columnName + "\")) != 0");
+                else
+                    builder.addStatement("model." + _info.fieldName + " = " + "_cursor." + _info.accessMethod + "(_cursor.getColumnIndex(\"" + _info.columnName + "\"))");
             }
 
             builder.returns(ClassName.get(_modelClass.getTypeElement()))

--- a/etil-sample/src/main/java/com/tractive/android/etil/sample/PetDetail.java
+++ b/etil-sample/src/main/java/com/tractive/android/etil/sample/PetDetail.java
@@ -15,4 +15,7 @@ public class PetDetail {
 
     @EtilField("birthday")
     public String birthday;
+
+    @EtilField("breed_mixed")
+    public boolean breed_mixed;
 }


### PR DESCRIPTION
Accessor methods for boolean datatypes do not exist in sqlite.
http://stackoverflow.com/questions/4088080/get-boolean-from-database-using-android-and-sqlite

The generated code converts the integer value from the table field to a boolean.
